### PR TITLE
fix -Wlogical-not-parentheses warning

### DIFF
--- a/gmpxx_mkII.h
+++ b/gmpxx_mkII.h
@@ -3133,9 +3133,11 @@ inline std::string mpf_to_base_string_fixed(const mpf_t value, int base, int fla
             formatted_base.insert(0, "0x0");
         } else if (base == 10) {
             formatted_base.insert(0, "0");
-            if (is_showpoint && prec == 0) {
-                formatted_base += ".";
-            } else if (!prec == 0) {
+            if (prec == 0) {
+                if (is_showpoint) {
+                    formatted_base += ".";
+                }
+            } else {
                 formatted_base += ".";
                 formatted_base += std::string(effective_prec, '0');
             }


### PR DESCRIPTION
(mpf_to_base_string_fixed): manual unroll so we don't check prec twice

contributed under BSD/LGPLv2+/GPLv3+ as see fit