### PR TITLE
fix issue with small long int

### DIFF
--- a/test_gmpxx_mkII.cpp
+++ b/test_gmpxx_mkII.cpp
@@ -916,7 +916,7 @@ void testInitializationAndAssignmentDouble_mpz_class() {
     std::cout << "testInitializationAndAssignmentDouble_mpz_class passed." << std::endl;
 }
 void testInitializationAndAssignmentInt_mpz_class() {
-    signed long int testValue = -31415926535L;
+    signed long long int testValue = -31415926535LL;
     const char *expectedValue = "-31415926535";
 
     mpz_class a = (mpz_class)testValue;


### PR DESCRIPTION
warning, I've just stumbled over this local change and don't remember the context from three months ago, but I'm quite sure that this was fixing a warning/error with environments where `sizeof(long int) != sizeof (long lonbg int)`